### PR TITLE
Fix gcc optim

### DIFF
--- a/STM32F1/hardware.c
+++ b/STM32F1/hardware.c
@@ -190,6 +190,8 @@ void setMspAndJump(u32 usrAddr) {
 
   funcPtr usrMain = (funcPtr) jumpAddr;
 
+  SET_REG(SCB_VTOR, (vu32) (usrAddr));
+
   asm volatile("msr msp, %0"::"g"
                (*(volatile u32 *)usrAddr));
 

--- a/STM32F1/hardware.c
+++ b/STM32F1/hardware.c
@@ -181,11 +181,23 @@ bool checkUserCode(u32 usrAddr) {
     }
 }
 
-void jumpToUser(u32 usrAddr) {
-    typedef void (*funcPtr)(void);
+void setMspAndJump(u32 usrAddr) {
+  // Dedicated function with no call to any function (appart the last call)
+  // This way, there is no manipulation of the stack here, ensuring that GGC
+  // didn't insert any pop from the SP after having set the MSP.
+  typedef void (*funcPtr)(void);
+  u32 jumpAddr = *(vu32 *)(usrAddr + 0x04); /* reset ptr in vector table */
 
-    u32 jumpAddr = *(vu32 *)(usrAddr + 0x04); /* reset ptr in vector table */
-    funcPtr usrMain = (funcPtr) jumpAddr;
+  funcPtr usrMain = (funcPtr) jumpAddr;
+
+  asm volatile("msr msp, %0"::"g"
+               (*(volatile u32 *)usrAddr));
+
+  usrMain();                                /* go! */
+}
+
+
+void jumpToUser(u32 usrAddr) {
 
     /* tear down all the dfu related setup */
     // disable usb interrupts, clear them, turn off usb, set the disc pin
@@ -201,10 +213,7 @@ void jumpToUser(u32 usrAddr) {
 // Does nothing, as PC12 is not connected on teh Maple mini according to the schemmatic     setPin(GPIOC, 12); // disconnect usb from host. todo, macroize pin
     systemReset(); // resets clocks and periphs, not core regs
 
-
-    __MSR_MSP(*(vu32 *) usrAddr);             /* set the users stack ptr */
-
-    usrMain();                                /* go! */
+    setMspAndJump(usrAddr);
 }
 
 void nvicInit(NVIC_InitTypeDef *NVIC_InitStruct) {


### PR DESCRIPTION
Hello Roger,
Please find a fix that prevented the bootloader to work with GCC 6.2.0. That might be the same issue you hit with GCC 4.9 as per the README.

Before the fix, here is the generated code for the function jumpToUser():

```
080008d0 <jumpToUser>:

void flashLock() {
    /* take down the HSI oscillator? it may be in use elsewhere */

    /* ensure all FPEC functions disabled and lock the FPEC */
    SET_REG(FLASH_CR, 0x00000080);
 80008d0:       2280            movs    r2, #128        ; 0x80
void jumpToUser(u32 usrAddr) {
 80008d2:       b570            push    {r4, r5, r6, lr}
 80008d4:       4604            mov     r4, r0
    SET_REG(FLASH_CR, 0x00000080);
 80008d6:       4b09            ldr     r3, [pc, #36]   ; (80008fc <jumpToUser+0x2c>)
    u32 jumpAddr = *(vu32 *)(usrAddr + 0x04); /* reset ptr in vector table */
 80008d8:       6845            ldr     r5, [r0, #4]
    SET_REG(FLASH_CR, 0x00000080);
 80008da:       601a            str     r2, [r3, #0]
    usbDsbISR();
 80008dc:       f7ff fe30       bl      8000540 <usbDsbISR>
    nvicDisableInterrupts();
 80008e0:       f7ff ffe4       bl      80008ac <nvicDisableInterrupts>
        usbDsbBus();
 80008e4:       f7ff fdf8       bl      80004d8 <usbDsbBus>
    systemReset(); // resets clocks and periphs, not core regs
 80008e8:       f7ff ff2c       bl      8000744 <systemReset>
    __MSR_MSP(*(vu32 *) usrAddr);             /* set the users stack ptr */
 80008ec:       6820            ldr     r0, [r4, #0]
 80008ee:       f7ff fc21       bl      8000134 <__MSR_MSP>
    usrMain();                                /* go! */
 80008f2:       462b            mov     r3, r5
}
 80008f4:       e8bd 4070       ldmia.w sp!, {r4, r5, r6, lr}  <——————————————————
    usrMain();                                /* go! */
 80008f8:       4718            bx      r3

```
This ends into seg fault, caused by the `ldmia.w sp!, {r4, r5, r6, lr}` attempting to pop after the new SP has been set, at the end of the RAM.

After my fix, here is the generated code:

```
080007c8 <setMspAndJump>:
  typedef void (*funcPtr)(void);
  u32 jumpAddr = *(vu32 *)(usrAddr + 0x04); /* reset ptr in vector table */

  funcPtr usrMain = (funcPtr) jumpAddr;

  SET_REG(SCB_VTOR, (vu32) (usrAddr));
 80007c8:       4a03            ldr     r2, [pc, #12]   ; (80007d8 <setMspAndJump+0x10>)
  u32 jumpAddr = *(vu32 *)(usrAddr + 0x04); /* reset ptr in vector table */
 80007ca:       6843            ldr     r3, [r0, #4]
  SET_REG(SCB_VTOR, (vu32) (usrAddr));
 80007cc:       6010            str     r0, [r2, #0]

  asm volatile("msr msp, %0"::"g"
               (*(volatile u32 *)usrAddr));
 80007ce:       6802            ldr     r2, [r0, #0]
  asm volatile("msr msp, %0"::"g"
 80007d0:       f382 8808       msr     MSP, r2

  usrMain();                                /* go! */
 80007d4:       4718            bx      r3
 80007d6:       bf00            nop
```
No /spurious/ pop :-)

The second commit also set the VTOR to the correct value, in case the application code doesn't do it properly.

I have tested on STM32F103, using GCC 6.2.0.

Regards
