### PR TITLE
Add timeout of MANIFEST_WAIT_RESET status

### DIFF
--- a/STM32F1/dfu.h
+++ b/STM32F1/dfu.h
@@ -45,6 +45,7 @@ typedef struct _DFUStatus {
     u8 bwPollTimeout2;
     u8 bState;  /* state of device at the time the host receives the message! */
     u8 iString;
+    u32 bwWaitResetTimeout;
 } DFUStatus;
 
 typedef enum _PLOT {


### PR DESCRIPTION
Add timeout of MANIFEST_WAIT_RESET status because the dfu-util on macOS does not issue USB reset.

discussed in this thread
http://www.stm32duino.com/viewtopic.php?f=28&t=2107