### PR TITLE
added option for 16MHz-crystal

### DIFF
--- a/hardware.c
+++ b/hardware.c
@@ -115,9 +115,14 @@ void setupCLK(void) {
     SET_REG(FLASH_ACR, 0x00000012);
 
     /* Configure PLL */
-#ifdef XTAL12M
+#if defined XTAL16M
+    // 16 MHz crystal  (using the Bit 17 PLLXTPRE=1 => HSE clock divided by 2 before PLL entry)
+    SET_REG(RCC_CFGR, GET_REG(RCC_CFGR) | 0x001F0400); /* pll=72Mhz(x9/2),APB1=36Mhz,AHB=72Mhz */
+#elif defined XTAL12M
+    // 12 MHz crystal
     SET_REG(RCC_CFGR, GET_REG(RCC_CFGR) | 0x00110400); /* pll=72Mhz(x6),APB1=36Mhz,AHB=72Mhz */
 #else
+    // 8 MHz crystal default
     SET_REG(RCC_CFGR, GET_REG(RCC_CFGR) | 0x001D0400); /* pll=72Mhz(x9),APB1=36Mhz,AHB=72Mhz */
 #endif
 


### PR DESCRIPTION
tested on STM32F103VE only but surely can be used on other STM32F103xC, STM32F103xD, STM32F103xE with the same clock PLL structure.
( http://stm32duino.com/viewtopic.php?p=39378#p39378 )

put an additional "#define XTAL16M 1" -statement in config.h (to the referring target-board section),
if needed.

(just the same procedure like it is done already for example on  TARGET_GD32F1_FRANKENMAPLE with the "#define XTAL12M 1" -statement)

  