### PR TITLE
Added platformio.ini for building with PlatformIO. Fixed one warning (calling a non-declared function).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ tags
 cscope.out
 build
 *~
+.pioenvs
+.piolibdeps
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json

--- a/hardware.h
+++ b/hardware.h
@@ -243,6 +243,7 @@ void gpio_write_bit(u32 bank, u8 pin, u8 val);
 unsigned int crMask(int pin);
 
 bool readPin(u32 bank, u8 pin);
+bool readButtonState();
 void strobePin(u32 bank, u8 pin, u8 count, u32 rate,u8 onState);
 
 void systemHardReset(void);

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,145 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:maple-mini]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_MAPLE_MINI -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:maple-rev3]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_MAPLE_REV3 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:maple-rev5]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_MAPLE_REV5 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pc13]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PC13 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pg15]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PG15 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pd2]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PD2 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pd1]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PD1 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pa1]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PA1 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pa1-button-pa8]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PA1_BUTTON_PA8 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pb9]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PB9 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pe2]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PE2 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pa9]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PA9 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pe5]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PE5 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pe5-button-pa0]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PE5_BUTTON_PA0 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pb7]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PB7 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pb0]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PB0 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:stbee]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_STBEE -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:naze32]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_NAZE32 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:generic-pb12]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GENERIC_F103_PB12 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:hytiny-stm32f103t]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_HYTINY_STM32F103T -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:dso138]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_DSO138 -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+
+[env:gd32f1-frankenmaple]
+platform = ststm32
+board = genericSTM32F103C8
+build_flags = -DTARGET_GD32F1_FRANKENMAPLE -Istm32_lib -Iusb_lib -Wl,-Tstm32_lib/c_only_md_high_density.ld
+src_filter = +<*> -<sketch_combiner/> -<stm32_lib/c_only_startup_user.s>
+


### PR DESCRIPTION
This one adds support for building the bootloader with PlatformIO (#48). Didn't test all build variants, but I've built the bootloader for my custom board and it works.

GCC version in PlatformIO is currently 7.2.1.