### PR TITLE
Fix button pins initialization (avoid modifying bits other than really needed)

### DIFF
--- a/hardware.c
+++ b/hardware.c
@@ -152,7 +152,7 @@ void setupLEDAndButton (void) {
     // SET_REG(AFIO_MAPR,(GET_REG(AFIO_MAPR) & ~AFIO_MAPR_SWJ_CFG) | AFIO_MAPR_SWJ_CFG_NO_JTAG_NO_SW);// Try to disable SWD AND JTAG so we can use those pins (not sure if this works).
 
 #if defined(BUTTON_BANK) && defined (BUTTON_PIN) && defined (BUTTON_PRESSED_STATE)
-    SET_REG(GPIO_CR(BUTTON_BANK,BUTTON_PIN),(GPIO_CR(BUTTON_BANK,BUTTON_PIN) & crMask(BUTTON_PIN)) | BUTTON_INPUT_MODE << CR_SHITF(BUTTON_PIN));
+    SET_REG(GPIO_CR(BUTTON_BANK,BUTTON_PIN),(GET_REG(GPIO_CR(BUTTON_BANK,BUTTON_PIN)) & crMask(BUTTON_PIN)) | BUTTON_INPUT_MODE << CR_SHITF(BUTTON_PIN));
 
     gpio_write_bit(BUTTON_BANK, BUTTON_PIN,1-BUTTON_PRESSED_STATE);// set pulldown resistor in case there is no button.
 #endif


### PR DESCRIPTION
When initializing pin mode via GPIO Control Register the code is supposed to change only bits that are really related to this pin. Due to a simple mistake the code changes other pins as well.

Instead of taking Control Register value as a source for bits manipulations, the code uses address of the register, not value. Interestingly, but similar expression 3 lines below is correct.

