### PR TITLE
usb clock is disabled before loading user firmware

### DIFF
--- a/hardware.c
+++ b/hardware.c
@@ -103,6 +103,8 @@ void systemReset(void) {
     SET_REG(RCC_CFGR, GET_REG(RCC_CFGR) & 0xFF80FFFF);
 
     SET_REG(RCC_CIR, 0x00000000);  /* disable all RCC interrupts */
+
+    pRCC->APB1ENR &= (~RCC_APB1ENR_USB_CLK);
 }
 
 void setupCLK(void) {


### PR DESCRIPTION
Usb-serial example from https://github.com/stm32-rs/stm32f1xx-hal loaded by STM32duino-bootloader can't bring up usb. The firmware loaded by internal bootloader or by patched STM32duino-bootloader works correct.
The patch was tested on bluepill board on linux.